### PR TITLE
Exclusión de usuarios y cursos marcados como eliminados

### DIFF
--- a/back/models/index.js
+++ b/back/models/index.js
@@ -16,6 +16,7 @@ if (config.use_env_variable) {
   sequelize = new Sequelize(config.database, config.username, config.password, config);
 }
 
+// Importa los modelos del directorio y los guarda en "db"
 fs
   .readdirSync(__dirname)
   .filter((file) => (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js'))
@@ -26,9 +27,19 @@ fs
   });
 
 Object.keys(db).forEach((modelName) => {
+
+  // Crea las asociaciones
   if (db[modelName].associate) {
     db[modelName].associate(db);
-  }
+  };
+
+  // Define y agrega la "scope" predeterminada
+  db[modelName].addScope('defaultScope', {
+    attributes: {
+      exclude: ['deletedAt']
+    }
+  });
+  
 });
 
 db.sequelize = sequelize;

--- a/back/providers/courseProvider.js
+++ b/back/providers/courseProvider.js
@@ -12,7 +12,7 @@ const createCourse = async (course) => {
 
 const getCourses = async () => {
     try {
-        return await Course.findAll({paranoid: false});//se muestran incluso los eliminados
+        return await Course.findAll();
     } catch (err) {
         console.error('Error when fetching courses.', err.message);
         throw err;
@@ -49,10 +49,7 @@ const deleteCourse = async (id) => {
 
 const getUsers = async (id, filterParams) => {
     try {
-        let options = {
-            where: {},
-            paranoid: false // se muestran incluso los eliminados
-        };
+        let options = { where: {} };
         if (filterParams.role) options.where.role = filterParams.role;
         const course = await Course.findByPk(id);
         return await course?.getUsers(options);

--- a/back/providers/userProvider.js
+++ b/back/providers/userProvider.js
@@ -49,10 +49,7 @@ const userValidate = async (data) => {
 
 const find = async (filterParams) => {
   try {
-    let options = {
-      where: {},
-      paranoid: false // se muestran incluso los eliminados
-    };
+    let options = { where: {} };
     if (filterParams.role) options.where.role = filterParams.role;
     return await db.User.findAll(options);
   } catch (error) {
@@ -83,10 +80,7 @@ const deleteUser = async (id) => {
 
 const getCourses = async (id, filterParams) => {
   try {
-      let options = {
-          where: {},
-          paranoid: false // se muestran incluso los eliminados
-      };
+      let options = { where: {} };
       if (filterParams.role) options.where.role = filterParams.role;
       const user = await db.User.findByPk(id);
       return await user?.getCourses(options);


### PR DESCRIPTION
Se configuraron las consultas de obtención de usuarios y cursos para que ya no incluyan los registros "eliminados".
También se excluyó el atributo deletedAt de las respuestas, aunque sea null.